### PR TITLE
Embed images in markdown export

### DIFF
--- a/js/bookutils.js
+++ b/js/bookutils.js
@@ -951,7 +951,7 @@ class BookUtil {
 						await this.walkForImages(entry.entries);
 					}
 
-					if (entry.type === "image") {
+					if (entry.type === "image" && !entry.data?.base64) {
 						const response = await fetch(Renderer.utils.getEntryMediaUrl(entry, "href", "img"));
 						if (!response) continue;
 
@@ -966,7 +966,7 @@ class BookUtil {
 					await this.walkForImages(input.entries);
 				}
 
-				if (input.type === "image") {
+				if (input.type === "image" && !input.data?.base64) {
 					const response = await fetch(Renderer.utils.getEntryMediaUrl(input, "href", "img"));
 					if (!response) return;
 

--- a/js/bookutils.js
+++ b/js/bookutils.js
@@ -379,18 +379,24 @@ class BookUtil {
         );
     	};
 
+			const doDownloadChapterText = async () => {
+				await this.walkForImages(this.curRender.data[this.curRender.chapter]);
+
+				const contentsInfo = this.curRender.fromIndex.contents[this.curRender.chapter];
+				DataUtil.userDownloadText(
+					`${this.curRender.fromIndex.name} - ${Parser.bookOrdinalToAbv(contentsInfo.ordinal).replace(/:/g, "")}${contentsInfo.name}.md`,
+					RendererMarkdown.get().render(this.curRender.data[this.curRender.chapter]),
+				);
+			};
+
 			this._TOP_MENU = ContextUtil.getMenu([
 				new ContextUtil.Action(
 					"Download Chapter as Markdown",
 					() => {
 						if (!~BookUtil.curRender.chapter) return doDownloadFullText();
-
-						const contentsInfo = this.curRender.fromIndex.contents[this.curRender.chapter];
-						DataUtil.userDownloadText(
-							`${this.curRender.fromIndex.name} - ${Parser.bookOrdinalToAbv(contentsInfo.ordinal).replace(/:/g, "")}${contentsInfo.name}.md`,
-							RendererMarkdown.get().render(this.curRender.data[this.curRender.chapter]),
-						);
-					},
+						
+						doDownloadChapterText();
+					}
 				),
 				new ContextUtil.Action(
 					`Download ${this.typeTitle} as Markdown`,
@@ -961,23 +967,22 @@ class BookUtil {
 						(entry.data ||= {}).base64 = await this._getImageDataURL(imgBlob);
 					}
 				}
-			} 
-				// else {
-				// console.log(input.type)
-				// if (input.type === "section" || input.type === "entries") {
-				// 	this.walkForImages2(input.entries);
-				// }
+			} else {
+				console.log(input.type)
+				if (input.entries) {
+					await this.walkForImages(input.entries);
+				}
 
-				// if (input.type === "image") {
-				// 	const response = await fetch(Renderer.utils.getEntryMediaUrl(input, "href", "img"));
-				// 	if (!response) {console.log("no response"); return};
+				if (input.type === "image") {
+					const response = await fetch(Renderer.utils.getEntryMediaUrl(input, "href", "img"));
+					if (!response) {console.log("no response"); return};
 
-				// 	const imgBlob = await response.blob();
-				// 	if (!imgBlob) {console.log("no blob"); return};
+					const imgBlob = await response.blob();
+					if (!imgBlob) {console.log("no blob"); return};
 					
-				// 	(input.data ||= {}).base64 = await this._getImageDataURL(imgBlob);
-				// }
-			// }
+					(input.data ||= {}).base64 = await this._getImageDataURL(imgBlob);
+				}
+			}
 		} catch (error) { 
 			console.error(error);
 		}

--- a/js/bookutils.js
+++ b/js/bookutils.js
@@ -947,38 +947,31 @@ class BookUtil {
 						await this.walkForImages(entry);
 					}
 
-					if (entry.type === "section" || entry.type === "entries") {
+					if (entry.entries) {
 						await this.walkForImages(entry.entries);
 					}
 
 					if (entry.type === "image") {
 						const response = await fetch(Renderer.utils.getEntryMediaUrl(entry, "href", "img"));
-						if (!response) {
-							console.log("No response");
-							continue;
-						};
+						if (!response) continue;
 
 						const imgBlob = await response.blob();
-						if (!imgBlob) {
-							console.log("No blob");
-							continue;
-						};
+						if (!imgBlob) continue;
 						
 						(entry.data ||= {}).base64 = await this._getImageDataURL(imgBlob);
 					}
 				}
 			} else {
-				console.log(input.type)
 				if (input.entries) {
 					await this.walkForImages(input.entries);
 				}
 
 				if (input.type === "image") {
 					const response = await fetch(Renderer.utils.getEntryMediaUrl(input, "href", "img"));
-					if (!response) {console.log("no response"); return};
+					if (!response) return;
 
 					const imgBlob = await response.blob();
-					if (!imgBlob) {console.log("no blob"); return};
+					if (!imgBlob) return;
 					
 					(input.data ||= {}).base64 = await this._getImageDataURL(imgBlob);
 				}
@@ -1005,27 +998,6 @@ class BookUtil {
 			fileReader.readAsDataURL(imageBlob);
 		});
 	}
-
-  // static walkForImages (entry, previousValues) {
-  //   console.log({type: entry.type, entry, previousValues});
-
-  //   if (Array.isArray(entry)) return [
-  //     ...previousValues,
-  //     ...entry.flatMap(item => this.walkForImages(item, previousValues))
-  //   ];
-
-  //   if (entry.type === "section" || entry.type === "entries") return [
-  //     ...previousValues,
-  //     ...this.walkForImages(entry.entries, previousValues)
-  //   ];
-
-  //   if (entry.type === "image") return [
-  //     ...previousValues,
-  //     entry
-  //   ];
-
-  //   return previousValues;
-  // }
 }
 // region Last render/etc
 BookUtil.curRender = {

--- a/js/bookutils.js
+++ b/js/bookutils.js
@@ -369,15 +369,15 @@ class BookUtil {
 
 		if (!this._TOP_MENU) {
 			const doDownloadFullText = async () => {
-        await this.walkForImages(this.curRender.data);
-    
-        DataUtil.userDownloadText(
-            `${this.curRender.fromIndex.name}.md`,
-            this.curRender.data
-                .map(chapter => RendererMarkdown.get().render(chapter))
-                .join("\n\n------\n\n"),
-        );
-    	};
+				await this.walkForImages(this.curRender.data);
+
+				DataUtil.userDownloadText(
+					`${this.curRender.fromIndex.name}.md`,
+					this.curRender.data
+						.map(chapter => RendererMarkdown.get().render(chapter))
+						.join("\n\n------\n\n"),
+				);
+			};
 
 			const doDownloadChapterText = async () => {
 				await this.walkForImages(this.curRender.data[this.curRender.chapter]);
@@ -394,9 +394,9 @@ class BookUtil {
 					"Download Chapter as Markdown",
 					() => {
 						if (!~BookUtil.curRender.chapter) return doDownloadFullText();
-						
+
 						doDownloadChapterText();
-					}
+					},
 				),
 				new ContextUtil.Action(
 					`Download ${this.typeTitle} as Markdown`,
@@ -966,10 +966,10 @@ class BookUtil {
 					(entry.data ||= {}).base64 = await this._getImageDataURL(imageUrl);
 				}
 			}
-		} catch (error) { 
+		} catch (error) {
 			JqueryUtil.doToast({
 				type: "warning",
-				content: error.message ?? error
+				content: error.message ?? error,
 			});
 		}
 	}

--- a/js/render-markdown.js
+++ b/js/render-markdown.js
@@ -560,7 +560,6 @@ class RendererMarkdown {
 		this._renderPrefix(entry, textStack, meta, options);
 
 		if (entry.data?.base64) {
-			console.log("base64 present", entry.data.base64)
 			textStack[0] += `![${entry.title || ""}](${entry.data.base64})`;
 		} else {
 			const href = this._renderImage_getUrl(entry);

--- a/js/render-markdown.js
+++ b/js/render-markdown.js
@@ -558,8 +558,15 @@ class RendererMarkdown {
 	// region images
 	_renderImage (entry, textStack, meta, options) {
 		this._renderPrefix(entry, textStack, meta, options);
-		const href = this._renderImage_getUrl(entry);
-		textStack[0] += `![${entry.title || ""}](${href})`;
+
+		if (entry.data?.base64) {
+			console.log("base64 present", entry.data.base64)
+			textStack[0] += `![${entry.title || ""}](${entry.data.base64})`;
+		} else {
+			const href = this._renderImage_getUrl(entry);
+			textStack[0] += `![${entry.title || ""}](${href})`;
+		}
+
 		this._renderSuffix(entry, textStack, meta, options);
 	}
 


### PR DESCRIPTION
Adds ability to embed images in markdown files.

The way this was achieved is as folllows:
- When exporting markdown it walks the tree of content for image entries
- uses the built in util in the renderer to get the URL for the image asset
- uses `fetch` to get the file contents and convert it to a blob
- uses the `FileReader` API to asynchronously generate a base64 dataURI from the blob

I was thinking it over and it might be a better UX to have the ability to opt into embedding the images as opposed to automatically doing so.  The way I can see this working is expanding the export menu to include new options `Download Chapter as markdown (embeded images)` and `Download Book as markdown (embeded images)` or something similar.  This would allow users who don't want the images to be able to exclude them by just not downloading them from the `5etools-img` repo.  What your thoughts are on it?