### PR TITLE
Changed the levels of 'developments' headers in adventure DoD

### DIFF
--- a/data/adventures.json
+++ b/data/adventures.json
@@ -1011,7 +1011,10 @@
 							"depth": 1,
 							"header": "20. Arauthator's Abyss"
 						},
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Leaving Oyaviggaton",
 						"Arauthator's Treasure",
 						"Conclusion"
@@ -3567,7 +3570,10 @@
 						"Private Meetings",
 						"A Change of Heart",
 						"Sorcere",
-						"Developments"
+						{
+							"depth": 1,
+							"header": "Developments"
+						}
 					]
 				},
 				{
@@ -3585,7 +3591,10 @@
 						"Let Them Speak Now...",
 						"Fighting the Faceless Lord",
 						"Victory or Defeat",
-						"Developments"
+						{
+							"depth": 1,
+							"header": "Developments"
+						}
 					]
 				},
 				{
@@ -16445,7 +16454,10 @@
 						"The Study Room",
 						"The Old Classroom",
 						"The Secret Laboratory",
-						"Developments"
+						{
+							"depth": 1,
+							"header": "Developments"
+						}
 					]
 				},
 				{
@@ -33588,9 +33600,15 @@
 					"headers": [
 						"Overview",
 						"Black Ivory Inn",
-						"Developments",
+					{
+						"depth": 1,
+						"header": "Developments"
+					},
 						"Buckledown Row",
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Chapel of Saint Brenna",
 						{
 							"depth": 1,
@@ -33632,7 +33650,10 @@
 							"depth": 1,
 							"header": "[10] Hidden Reliquary"
 						},
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Eckerman Mill",
 						"Rat's Nest Tavern",
 						{
@@ -33667,7 +33688,10 @@
 							"depth": 1,
 							"header": "[8] Seer's Den"
 						},
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Reed Manor",
 						{
 							"depth": 1,
@@ -33693,7 +33717,10 @@
 							"depth": 1,
 							"header": "[12] Materials Storage"
 						},
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Shrine of Morrigan",
 						"Smithy on the Scar",
 						{
@@ -33724,7 +33751,10 @@
 							"depth": 1,
 							"header": "[6] Gun Platforms"
 						},
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Stick's Ferry"
 					]
 				},
@@ -33736,13 +33766,25 @@
 					},
 					"headers": [
 						"Overview",
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Cosmological Clocktower",
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"The Crater",
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Kleinberg Estate",
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Old Town Cistern",
 						{
 							"depth": 1,
@@ -33780,7 +33822,10 @@
 							"depth": 1,
 							"header": "[4] Underground Lake"
 						},
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Queen's Park",
 						{
 							"depth": 1,
@@ -33798,9 +33843,15 @@
 							"depth": 1,
 							"header": "[4] Underground Pond"
 						},
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Rose Theatre",
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Saint Vitruvio's Cathedral",
 						{
 							"depth": 1,
@@ -33846,7 +33897,10 @@
 							"depth": 1,
 							"header": "[10] Argonath's Rest"
 						},
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Slaughterstone Square"
 					]
 				},
@@ -33898,7 +33952,10 @@
 						"Court of Thieves",
 						"Drakkenheim Garrison",
 						"Inscrutable Tower",
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Saint Selina's Monastery"
 					]
 				},
@@ -33981,7 +34038,10 @@
 						"Main Entrance",
 						"Throne Room",
 						"Dungeons of Drakkenheim",
-						"Developments",
+						{
+							"depth": 1,
+							"header": "Developments"
+						},
 						"Closing the Dimensional Rift",
 						"Beyond the Dimensional Rift",
 						"Eternal Custodian",


### PR DESCRIPTION
### Typos'etc
**ISSUE DESCRIPTION** 
> For Dungeons of Drakkenheim, some of the header levels used seem to me to be inappropriate. Specifically, any section labeled "Developments" is given the same header level as the adventure-location that the development discusses. Visually, it's presented in a separate block from the flow of text (this specific block format frequently interrupts text flow in other places where it's used).
I think that these "developments" sections should probably be in some kind of block, and be included underneath its respective adventure-location, rather than as a same-level header.

**NOTE**
Hi ! Im a junior dev, first time collaborating. I've fixed what he asked, make sure to verify that everything is fine. If there is something wrong, feel free to reach me ! 